### PR TITLE
l10n for zh-Hant and migrate UIAlertView

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ func postComment() {
 
 ```
 
+4(Optional).Call `SwiftRater.rateApp()` to let your users to review your app on the App Store/in your app directly.
+
+```
+func rateButtonDidClick(sender: UIButton) {
+    // do something ..
+
+	SwiftRater.rateApp()
+}
+
+```
+
 ## Example
 
 This example states that the rating request is only shown when the app has been launched 5 times and after 7 days, remind 5 days after if later selected.

--- a/SwiftRater.xcodeproj/project.pbxproj
+++ b/SwiftRater.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		64B62F581E8E49AF000FFF09 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/SwiftRaterLocalization.strings; sourceTree = "<group>"; };
 		64B62F591E8E49C0000FFF09 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/SwiftRaterLocalization.strings; sourceTree = "<group>"; };
 		64B62F5A1E8E49CC000FFF09 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/SwiftRaterLocalization.strings; sourceTree = "<group>"; };
+		AA4717E21EA3CAC500C4EBC4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SwiftRaterLocalization.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -240,6 +241,7 @@
 				sk,
 				sv,
 				ms,
+				"zh-Hant",
 			);
 			mainGroup = 645FF65B1E8B8CD0001D5563;
 			productRefGroup = 645FF6661E8B8CD0001D5563 /* Products */;
@@ -334,6 +336,7 @@
 				64B62F581E8E49AF000FFF09 /* ro */,
 				64B62F591E8E49C0000FFF09 /* sv */,
 				64B62F5A1E8E49CC000FFF09 /* ms */,
+				AA4717E21EA3CAC500C4EBC4 /* zh-Hant */,
 			);
 			name = SwiftRaterLocalization.strings;
 			sourceTree = "<group>";

--- a/SwiftRater/SwiftRater.swift
+++ b/SwiftRater/SwiftRater.swift
@@ -138,6 +138,16 @@ public class SwiftRater: NSObject {
             SwiftRater.shared.showRatingAlert()
         }
     }
+    
+    public static func rateApp() {
+        if #available(iOS 10.3, *) {
+            SKStoreReviewController.requestReview()
+        } else {
+            SwiftRater.shared.rateApp()
+        }
+        
+        UsageDataManager.shared.isRateDone = true
+    }
 
     public static func reset() {
         UsageDataManager.shared.reset()
@@ -303,7 +313,7 @@ extension SwiftRater: UIAlertViewDelegate {
         }
     }
 
-    private func rateApp() {
+    fileprivate func rateApp() {
         #if arch(i386) || arch(x86_64)
             print("APPIRATER NOTE: iTunes App Store is not supported on the iOS simulator. Unable to open App Store page.");
         #else

--- a/SwiftRater/zh-Hans.lproj/SwiftRaterLocalization.strings
+++ b/SwiftRater/zh-Hans.lproj/SwiftRaterLocalization.strings
@@ -5,7 +5,7 @@
   Created by FUJIKI TAKESHI on 2017/03/28.
   Copyright © 2017 com.takecian. All rights reserved.
 */
-"Rater.title" = "如果你喜欢使用%@，你介意花一点时间给它评分吗？不会超过一分钟。感谢您的支持！";
-"Rate %@" = "给%@评分";
+"Rater.title" = "如果你喜欢使用「%@」，你介意花一点时间给它评分吗？不会超过一分钟。感谢您的支持！";
+"Rate %@" = "给「%@」评分";
 "No, Thanks" = "不，谢谢";
 "Remind me later" = "稍后提醒我";

--- a/SwiftRater/zh-Hant.lproj/SwiftRaterLocalization.strings
+++ b/SwiftRater/zh-Hant.lproj/SwiftRaterLocalization.strings
@@ -5,7 +5,7 @@
   Created by Zheng-Xiang Ke on 2017/04/17.
   Copyright © 2017 com.takecian. All rights reserved.
 */
-"Rater.title" = "如果你喜歡使用%@，你介意花一點時間給它評分嗎？不會超過一分鐘。感謝您的支持！";
-"Rate %@" = "給%@評分";
+"Rater.title" = "如果你喜歡使用「%@」，你介意花一點時間給它評分嗎？不會超過一分鐘。感謝您的支持！";
+"Rate %@" = "給「%@」評分";
 "No, Thanks" = "不，謝謝";
 "Remind me later" = "稍後提醒我";

--- a/SwiftRater/zh-Hant.lproj/SwiftRaterLocalization.strings
+++ b/SwiftRater/zh-Hant.lproj/SwiftRaterLocalization.strings
@@ -1,0 +1,11 @@
+/* 
+  SwiftRaterLocalization.strings
+  SwiftRater
+
+  Created by Zheng-Xiang Ke on 2017/04/17.
+  Copyright © 2017 com.takecian. All rights reserved.
+*/
+"Rater.title" = "如果你喜歡使用%@，你介意花一點時間給它評分嗎？不會超過一分鐘。感謝您的支持！";
+"Rate %@" = "給%@評分";
+"No, Thanks" = "不，謝謝";
+"Remind me later" = "稍後提醒我";


### PR DESCRIPTION
- Add support language: zh-Hant and add quotation marks for app name in Chinese to highlight the app name.

- UIAlertView is deprecated, so migrate it to UIAlertController.

- A SwiftRater's caller can lead his users to review his app directly by invoking SwiftRater.rateApp().