### PR TITLE
Add the action=write-review to update the review link for the App Store

### DIFF
--- a/SwiftRater/SwiftRater.swift
+++ b/SwiftRater/SwiftRater.swift
@@ -312,7 +312,7 @@ public class SwiftRater: NSObject {
             print("APPIRATER NOTE: iTunes App Store is not supported on the iOS simulator. Unable to open App Store page.");
         #else
             guard let appId = self.appID else { return }
-            let reviewURL = "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=\(appId)&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software";
+            let reviewURL = "itms-apps://itunes.apple.com/app/id\(appId)?action=write-review";
             guard let url = URL(string: reviewURL) else { return }
             UIApplication.shared.openURL(url)
         #endif


### PR DESCRIPTION
According to the Apple Document: https://developer.apple.com/reference/storekit/skstorereviewcontroller/2851536-requestreview.
"To automatically open a page on which users can write a review in the App Store, append the query parameter action=write-review to your product URL."

So update the review link to let users can review the app easily.