### PR TITLE
adding `isRateDone: Bool`

### DIFF
--- a/SwiftRater/SwiftRater.swift
+++ b/SwiftRater/SwiftRater.swift
@@ -77,6 +77,10 @@ import StoreKit
 
     @objc public static var shared = SwiftRater()
 
+    @objc public static var isRateDone: Bool {
+        return UsageDataManager.shared.isRateDone
+    }
+    
     fileprivate var appID: Int?
 
     private static var appVersion: String {


### PR DESCRIPTION
I propose exposing a computed property `isRateDone: Bool` for an app to behave accordingly, i.e. hiding the button to rate the app (I know, it's not recommended to have such a button in the first place, but it happens)