### PR TITLE
Exclude Info.plist from target in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,12 +16,14 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftRater",
-            path: "SwiftRater"
+            path: "SwiftRater",
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "SwiftRaterTests",
             dependencies: ["SwiftRater"],
-            path: "SwiftRaterTests"
+            path: "SwiftRaterTests",
+            exclude: ["Info.plist"]
         ),
     ]
 )


### PR DESCRIPTION
Because the latest Xcode complains about it, if SwiftRater is installed as a Swift Package.