### PR TITLE
Allow for an “any” strategy for ratings conditions as opposed to all having to be met

### DIFF
--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -15,9 +15,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-
+        SwiftRater.conditionsMetMode = .any
         SwiftRater.daysUntilPrompt = 1
-        SwiftRater.usesUntilPrompt = 1
+        SwiftRater.usesUntilPrompt = 3
+        SwiftRater.significantUsesUntilPrompt = 5
         SwiftRater.daysBeforeReminding = 1
         SwiftRater.showLaterButton = true
         SwiftRater.showLog = true

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        SwiftRater.conditionsMetMode = .any
+        SwiftRater.conditionsMetMode = .all
         SwiftRater.daysUntilPrompt = 1
         SwiftRater.usesUntilPrompt = 3
         SwiftRater.significantUsesUntilPrompt = 5

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -13,6 +13,7 @@ class ViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        SwiftRater.incrementSignificantUsageCount()
         SwiftRater.check(host: self)
 
         // If want to navigate app review page, use `rateApp()`.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can set properties you want to apply.
 | Property      | Description           |
 | :------------- |:-------------|
 | debugMode      | Shows review request every time. Default false, **need to set false when you submit app to AppStore**. |
+| conditionsMetMode | Possible values: `.any`, `.all` (default)<br /> Setting this to `.any` allows the prompt to be shown **when any one or more of your criteria have been met**.  |
 | showLaterButton | Show Later button in review request dialong, valid for iOS10.2 or before devices.|
 | daysBeforeReminding | Days until reminder popup if the user chooses `rate later`,  valid for iOS10.2 or before devices.      |
 
@@ -132,6 +133,15 @@ If you wanted to show the request after 5 days only and remind 7 days after if l
 SwiftRater.daysUntilPrompt = 5
 SwiftRater.daysBeforeReminding = 7
 SwiftRater.appLaunched()
+```
+
+If you wanted to show the rquest after a user performs 10 significant actions before 5 days or 5 uses have passed:
+
+```
+SwiftRater.conditionsMetMode = .any
+SwiftRater.daysUntilPrompt = 5
+SwiftRater.usesUntilPrompt = 5
+SwiftRater.significantUsesUntilPrompt = 10
 ```
 
 ## Customize text

--- a/SwiftRater.podspec
+++ b/SwiftRater.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftRater'
-  s.version          = '2.0.0'
+  s.version          = '2.1.0'
   s.summary          = 'A utility that reminds your iPhone app users to review the app written in pure Swift.'
 
 # This description is used to generate tags and improve search results.

--- a/SwiftRater/SwiftRater.swift
+++ b/SwiftRater/SwiftRater.swift
@@ -13,6 +13,11 @@ import AppKit
 #endif
 import StoreKit
 
+@objc public enum SwiftRaterConditionsMetMode: Int {
+    case all
+    case any
+}
+
 @objc public class SwiftRater: NSObject {
 
     enum ButtonIndex: Int {
@@ -62,6 +67,14 @@ import StoreKit
         }
         set {
             UsageDataManager.shared.debugMode = newValue
+        }
+    }
+    @objc public static var conditionsMetMode: SwiftRaterConditionsMetMode {
+        get {
+            return UsageDataManager.shared.conditionsMetMode
+        }
+        set {
+            UsageDataManager.shared.conditionsMetMode = newValue
         }
     }
 


### PR DESCRIPTION
Many users of ratings prompts like this one want to the prompt to happen when one or more of the conditions have been met as opposed to all of them, which is the current logic.

For example, with the below settings and the original logic, 5 days, 5 uses, and 10 significant uses would have to happen before the prompt is shown.

```
SwiftRater.daysUntilPrompt = 5
SwiftRater.usesUntilPrompt = 5
SwiftRater.significantUsesUntilPrompt = 10
```

Now, if you change the code as follows, only one of those conditions needs to be met:

```
SwiftRater.conditionsMetMode = .any
SwiftRater.daysUntilPrompt = 5
SwiftRater.usesUntilPrompt = 5
SwiftRater.significantUsesUntilPrompt = 10
```

So for example, if a user performs 10 significant actions before 5 days or 5 uses have passed, SwiftRater will now show the prompt.  Please note that the default strategy is still `.all` so this new behavior is completely opt-in for users of this library.

