### PR TITLE
Support for Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
         .target(
             name: "SwiftRater",
             path: "SwiftRater",
-            resources: [.copy("PrivacyInfo.xcprivacy")],
-            exclude: ["Info.plist"]
+            exclude: ["Info.plist"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "SwiftRaterTests",

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .target(
             name: "SwiftRater",
             path: "SwiftRater",
+            resources: [.copy("PrivacyInfo.xcprivacy")],
             exclude: ["Info.plist"]
         ),
         .testTarget(

--- a/SwiftRater.podspec
+++ b/SwiftRater.podspec
@@ -32,4 +32,5 @@ SwiftRater is a class that you can drop into any iPhone app that will help remin
 
   s.source_files = 'SwiftRater/**/*'
   s.exclude_files = 'SwiftRater/**/*.{plist}'
+  s.resource_bundles = {"SwiftRater" => ["SwiftRater/PrivacyInfo.xcprivacy"]}
 end

--- a/SwiftRater.xcodeproj/project.pbxproj
+++ b/SwiftRater.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		645FF6881E8B8D6A001D5563 /* SwiftRaterLocalization.strings in Resources */ = {isa = PBXBuildFile; fileRef = 645FF68A1E8B8D6A001D5563 /* SwiftRaterLocalization.strings */; };
 		645FF6951E8B9053001D5563 /* SwiftRaterErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645FF6941E8B9053001D5563 /* SwiftRaterErrorCode.swift */; };
 		645FF6971E8B906E001D5563 /* SwiftRaterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645FF6961E8B906E001D5563 /* SwiftRaterError.swift */; };
+		AA54CF342B86FAE0006BF411 /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = AA54CF322B86FA69006BF411 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,6 +28,19 @@
 			remoteInfo = SwiftRater;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		AA54CF332B86FAD9006BF411 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				AA54CF342B86FAE0006BF411 /* PrivacyInfo.xcprivacy in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		645FF6651E8B8CD0001D5563 /* SwiftRater.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftRater.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -70,6 +84,7 @@
 		64B62F591E8E49C0000FFF09 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/SwiftRaterLocalization.strings; sourceTree = "<group>"; };
 		64B62F5A1E8E49CC000FFF09 /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/SwiftRaterLocalization.strings; sourceTree = "<group>"; };
 		AA4717E21EA3CAC500C4EBC4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SwiftRaterLocalization.strings"; sourceTree = "<group>"; };
+		AA54CF322B86FA69006BF411 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +134,7 @@
 				645FF6821E8B8D0B001D5563 /* UsageDataManager.swift */,
 				645FF6681E8B8CD0001D5563 /* SwiftRater.h */,
 				645FF6691E8B8CD0001D5563 /* Info.plist */,
+				AA54CF322B86FA69006BF411 /* PrivacyInfo.xcprivacy */,
 				645FF68A1E8B8D6A001D5563 /* SwiftRaterLocalization.strings */,
 			);
 			path = SwiftRater;
@@ -155,6 +171,7 @@
 				645FF6611E8B8CD0001D5563 /* Frameworks */,
 				645FF6621E8B8CD0001D5563 /* Headers */,
 				645FF6631E8B8CD0001D5563 /* Resources */,
+				AA54CF332B86FAD9006BF411 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/SwiftRater/PrivacyInfo.xcprivacy
+++ b/SwiftRater/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Sorry. I can only use simple English. I use machine translation.

SwiftRater is using UserDefaults. I thought Privacy Manifest support was needed.

This Pull Request fixed the following items:
* Add PrivacyInfo.xcprivacy when installed from CocoaPods
* Add PrivacyInfo.xcprivacy when installed from Carthage
* Add PrivacyInfo.xcprivacy when installed from Swift PM

ref: #47

----
Original Text: 
SwiftRaterでは、アプリの起動回数など各種データを保持するためにUserDefaultsを利用しており、Privacy Manifest対応が必要だと考えています。このPull Requestでは以下の項目に対応しました。

* CocoaPodsからインストールした場合、PrivacyInfo.xcprivacy が追加されるようにした
* Carthageからインストールした場合、PrivacyInfo.xcprivacy が追加されるようにした
* Swift PMからインストールした場合、PrivacyInfo.xcprivacy が追加されるようにした