### PR TITLE
fix typo / adding point value in increment significan use action

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ SwiftRater.daysBeforeReminding = 7
 SwiftRater.appLaunched()
 ```
 
-If you wanted to show the rquest after a user performs 10 significant actions before 5 days or 5 uses have passed:
+If you wanted to show the request after a user performs 10 significant actions before 5 days or 5 uses have passed:
 
 ```
 SwiftRater.conditionsMetMode = .any

--- a/SwiftRater/UsageDataManager.swift
+++ b/SwiftRater/UsageDataManager.swift
@@ -177,8 +177,8 @@ class UsageDataManager {
     usesCount = usesCount + 1
   }
   
-  func incrementSignificantUseCount() {
-    significantEventCount = significantEventCount + 1
+  func incrementSignificantUseCount(point: Int = 1) {
+    significantEventCount = significantEventCount + point
   }
   
   func saveReminderRequestDate() {


### PR DESCRIPTION
there is a little typo on ReadMe.

and when you increase significant use count, it depends on user action.
but that will be more import action than the others.
currently we can increase one by one. so I added point value.

thank you for your work.