### PR TITLE
Fix appName setter

### DIFF
--- a/SwiftRater/SwiftRater.swift
+++ b/SwiftRater/SwiftRater.swift
@@ -208,7 +208,7 @@ import StoreKit
       _appName
     }
     set {
-      _countryCode = newValue
+      _appName = newValue
     }
   }
 


### PR DESCRIPTION
The `appName` setter is not working, possibly a copy paste mistake.

This PR fixes this.